### PR TITLE
Read in user arguments and misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,13 @@ do this separately with a separate command since the Narrative API is
 slow and unstable, and we want the photo and video downloads to go as
 fast as possible.
 
-* run the command `python ripper.py`
-* when prompted enter the email you used to register with narrative
-* when prompted enter your narrative password
-* when prompted enter the full path to where you would like to download your data from Narrative to
+* run the command `ripper.py [-h] [-m MAX_RETRY] [-e EMAIL] [-p PASSWORD] [-o OUTPUT_PATH]`
+  * none of the parameters are required; when any of the necessary parameters are not specified, you will be prompted to enter them
+  * `-h`: show help information
+  * `-m`, `--max-retry`: the max number of times that ripper reties if there is any communication issue; when unspecified, ripper will retry indefinitely
+  * `-e`, `--email`: the email you used to register with narrative
+  * `-p`, `--password`: your narrative password
+  * `-o`, `--output-path`: the full path to where you would like to download your data from Narrative to
 * sit back and wait
 
 ### Run the content downloader
@@ -134,14 +137,11 @@ the script if you experience issue. You might be able to find some
 information about this in my posts in the official
 [Narrative Facebook group](https://www.facebook.com/groups/NarrativeLounge/permalink/1138896219481247).
 
-There is also a branch of the project called
-[allow-failure](https://github.com/deadcyclo/narrative-ripper/tree/allow-failure). The
-ripper in this branch will instead of retrying metadata for moments
-and sub moment data indefinitely, only retry 10 times before
-continuing. This allows you to continue retrieving metadata, even if
-some of the metadata is corrupt. This branch will not be merged to
-master, as it is a fallback for those of you who have issues with bad
-data.
+You can specify a max retry when running the ripper (e.g. `-m 10`,
+`--max-retry 10`), which will only retry the specified times before
+continuing, instead of retrying metadata for moments and sub moment
+data indefinitely. This allows you to continue retrieving metadata,
+even if some of the metadata is corrupt.
 
 ## Bug reporting
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,23 @@ application again. The downloader simply checks if a file with the
 given name exists in the correct location to determine if it should
 download or not. If no file is found, the file will be downloaded.
 
+## Data issues and crashes
+
+It seems that the Narratives dataquality isn't very good, and some
+people have data with a lot of errors in it. You might need to tweak
+the script if you experience issue. You might be able to find some
+information about this in my posts in the official
+[Narrative Facebook group](https://www.facebook.com/groups/NarrativeLounge/permalink/1138896219481247).
+
+There is also a branch of the project called
+[allow-failure](https://github.com/deadcyclo/narrative-ripper/tree/allow-failure). The
+ripper in this branch will instead of retrying metadata for moments
+and sub moment data indefinitely, only retry 10 times before
+continuing. This allows you to continue retrieving metadata, even if
+some of the metadata is corrupt. This branch will not be merged to
+master, as it is a fallback for those of you who have issues with bad
+data.
+
 ## Bug reporting
 
 Please open a ticket here on github, and I'll get back to you as soon

--- a/ripper.py
+++ b/ripper.py
@@ -86,7 +86,6 @@ def get_moments(session, url, subpath, name):
     return moments
 
 def do_token_stuff(token):
-  print token['access_token']
   session = requests.Session()
   session.headers.update({'Authorization': 'Bearer {key}'.format(key=token['access_token'])})
 
@@ -128,6 +127,13 @@ if __name__ == "__main__":
 
     try:
         token = get_token(email, password)
+        if 'access_token' not in token:
+            for key, value in token.iteritems():
+                print "{k}: {v}".format(k=key, v=value)
+            sys.exit(-1)
+        else:
+            print "Authentication succeeded"
+            print "Access token: {t})".format(t=token['access_token'])
     except:
         print "Incorrect email or password."
         sys.exit(-1)

--- a/ripper.py
+++ b/ripper.py
@@ -18,7 +18,7 @@
 
 # TODO: Download tags, faces, comments, account and device info
 
-import requests, time, json, string, os.path, sys, argparse
+import requests, time, json, string, os.path, sys, argparse, getpass
 
 def mkdir_recursive(path):
     sub_path = os.path.dirname(path)
@@ -122,7 +122,7 @@ if __name__ == "__main__":
         email = args['email']
 
     if args['password'] is None:
-        password = raw_input("Enter your password: ")
+        password = getpass.getpass(prompt='Enter your password: ')
     else:
         password = args['password']
 


### PR DESCRIPTION
@deadcyclo Thank you for creating this project.

This pull request contains the following changes:
1. Read in user arguments such that `email`, `password` and `path` can be specified directly. When any of the arguments is missing, users will still be prompted to enter them.
2. Allow users to specify `max-retry` to disable indefinite retry. This incorporates the `allow-failure` branch, which can be removed if this pull request is merged.
3. Use `getpass` to read password.
4. Narrative server seems to have changed. When authentication fails, no exception is thrown now. Instead, the following json will be returned: `{u'error_description': u'Invalid credentials given.', u'error': u'invalid_grant'}`. Modifications are made accordingly.
